### PR TITLE
updated .login position: absolute closes PredixDev/px-login#12

### DIFF
--- a/css/px-login.css
+++ b/css/px-login.css
@@ -664,7 +664,7 @@ button.btn {
   width: 55px; }
 
 .login {
-  position: fixed;
+  position: absolute;
   bottom: 0;
   padding: 0 1rem 1rem; }
   .login > div {


### PR DESCRIPTION
# Pull Request

Hi, this resolves iss12 in that the login button overflows into the footer.

simply updated the css of .login to be position: absolute rather than position: fixed
